### PR TITLE
Update TERRAFORM_VERSION to 1.9.6

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -6,7 +6,7 @@ on:
     - main
 
 env:
-  TERRAFORM_VERSION: 1.9.5
+  TERRAFORM_VERSION: 1.9.6
 
 jobs:
 


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/workflow.yaml` file. The change updates the Terraform version used in the workflow.

* [`.github/workflows/workflow.yaml`](diffhunk://#diff-fde0e5d64aae13964fdda6d47af304cf1a7015cbc17e440ac4a5e662ee1d875eL9-R9): Updated `TERRAFORM_VERSION` from `1.9.5` to `1.9.6`.