### PR TITLE
Update Terraform plan to include destroy step

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -39,7 +39,7 @@ jobs:
       run : terraform -chdir=./terraform/azure validate
 
     - name: Step 06 - Terraform Plan
-      run : terraform -chdir=./terraform/azure plan -out tfplan
+      run : terraform -chdir=./terraform/azure plan -destroy -out tfplan
 
     - name: Step 07 - Terraform Apply
       run : terraform -chdir=./terraform/azure apply tfplan


### PR DESCRIPTION
This pull request includes a change to the Terraform workflow configuration in the GitHub Actions workflow file. The most important change is the modification of the Terraform plan command to include the `-destroy` flag.

Changes in Terraform workflow configuration:

* [`.github/workflows/workflow.yaml`](diffhunk://#diff-fde0e5d64aae13964fdda6d47af304cf1a7015cbc17e440ac4a5e662ee1d875eL42-R42): Modified the Terraform plan step to include the `-destroy` flag, which will create a plan to destroy all resources managed by the configuration.