### PR TITLE
Add virtual machines vm03 and vm04 with associated network interfaces…

### DIFF
--- a/terraform/azure/main.tf
+++ b/terraform/azure/main.tf
@@ -179,3 +179,109 @@ resource "azurerm_network_interface_backend_address_pool_association" "vm02" {
     network_interface_id    = azurerm_network_interface.vm02.id
     backend_address_pool_id = azurerm_lb_backend_address_pool.lb.id
 }
+
+resource "azurerm_virtual_machine" "vm03" {
+    name                  = "vm03"
+    location              = azurerm_resource_group.rg.location
+    resource_group_name   = azurerm_resource_group.rg.name
+    network_interface_ids = [azurerm_network_interface.vm03.id]
+    vm_size               = "Standard_DS1_v2"
+
+    delete_os_disk_on_termination    = true
+    delete_data_disks_on_termination = true
+
+    storage_image_reference {
+        publisher = "Canonical"
+        offer     = "UbuntuServer"
+        sku       = "18.04-LTS"
+        version   = "latest"
+    }
+
+    storage_os_disk {
+        name              = "vm03-os-disk"
+        caching           = "ReadWrite"
+        create_option     = "FromImage"
+        managed_disk_type = "Standard_LRS"
+    }
+
+    os_profile {
+        computer_name  = "vm03"
+        admin_username = "adminuser"
+        admin_password = "Password1234!"
+    }
+
+    os_profile_linux_config {
+        disable_password_authentication = false
+    }
+}
+
+resource "azurerm_virtual_machine" "vm04" {
+    name                  = "vm04"
+    location              = azurerm_resource_group.rg.location
+    resource_group_name   = azurerm_resource_group.rg.name
+    network_interface_ids = [azurerm_network_interface.vm04.id]
+    vm_size               = "Standard_DS1_v2"
+
+    delete_os_disk_on_termination    = true
+    delete_data_disks_on_termination = true
+
+    storage_image_reference {
+        publisher = "Canonical"
+        offer     = "UbuntuServer"
+        sku       = "18.04-LTS"
+        version   = "latest"
+    }
+
+    storage_os_disk {
+        name              = "vm04-os-disk"
+        caching           = "ReadWrite"
+        create_option     = "FromImage"
+        managed_disk_type = "Standard_LRS"
+    }
+
+    os_profile {
+        computer_name  = "vm04"
+        admin_username = "adminuser"
+        admin_password = "Password1234!"
+    }
+
+    os_profile_linux_config {
+        disable_password_authentication = false
+    }
+}
+
+resource "azurerm_network_interface" "vm03" {
+    name                = "vm03-nic"
+    location            = azurerm_resource_group.rg.location
+    resource_group_name = azurerm_resource_group.rg.name
+
+    ip_configuration {
+        name                          = "internal"
+        subnet_id                     = azurerm_subnet.vnet.id
+        private_ip_address_allocation = "Dynamic"
+    }
+}
+
+resource "azurerm_network_interface" "vm04" {
+    name                = "vm04-nic"
+    location            = azurerm_resource_group.rg.location
+    resource_group_name = azurerm_resource_group.rg.name
+
+    ip_configuration {
+        name                          = "internal"
+        subnet_id                     = azurerm_subnet.subnet.id
+        private_ip_address_allocation = "Dynamic"
+    }
+}
+
+resource "azurerm_network_interface_backend_address_pool_association" "vm03" {
+    ip_configuration_name   = "internal"
+    network_interface_id    = azurerm_network_interface.vm03.id
+    backend_address_pool_id = azurerm_lb_backend_address_pool.lb.id
+}
+
+resource "azurerm_network_interface_backend_address_pool_association" "vm04" {
+    ip_configuration_name   = "internal"
+    network_interface_id    = azurerm_network_interface.vm04.id
+    backend_address_pool_id = azurerm_lb_backend_address_pool.lb.id
+}

--- a/terraform/azure/scripts/cloud_init.sh
+++ b/terraform/azure/scripts/cloud_init.sh
@@ -7,4 +7,4 @@ echo "Install Apache"
 sudo apt install apache2 -y
 
 echo "Install application"
-echo "Bem vindos ao TDC São Paulo 2024" > /var/www/html/index.html
+echo "Bem vindos ao TDC SP 2024" > /var/www/html/index.html


### PR DESCRIPTION
This pull request introduces new resources and updates existing scripts to enhance the infrastructure setup on Azure. The most significant changes include adding new virtual machines and network interfaces, as well as updating a script message.

New resources added:

* [`terraform/azure/main.tf`](diffhunk://#diff-a72b7b93508224bfaeef0ffa2613d32b06136b4b3c4b8d7f32557def0f2e216eR182-R287): Added `azurerm_virtual_machine` resources for `vm03` and `vm04`, including their configurations such as storage, OS profile, and network interfaces.
* [`terraform/azure/main.tf`](diffhunk://#diff-a72b7b93508224bfaeef0ffa2613d32b06136b4b3c4b8d7f32557def0f2e216eR182-R287): Added `azurerm_network_interface` resources for `vm03` and `vm04`, including their IP configurations.
* [`terraform/azure/main.tf`](diffhunk://#diff-a72b7b93508224bfaeef0ffa2613d32b06136b4b3c4b8d7f32557def0f2e216eR182-R287): Added `azurerm_network_interface_backend_address_pool_association` resources for `vm03` and `vm04` to associate them with the backend address pool of the load balancer.

Script updates:

* [`terraform/azure/scripts/cloud_init.sh`](diffhunk://#diff-f4a4ad4eb7a4c0f0c47016cbd745e7c4e869a4c2c767394d692c2eb4f68ea44bL10-R10): Updated the welcome message in the application installation script to reflect the new event name.… and backend address pool associations