### PR TITLE
Refactor workflow.yaml to improve job names and add dependency betwee…

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -15,7 +15,7 @@ env:
 jobs:
 
   CI-test:
-    name: CI Test
+    name: Test
     runs-on: ubuntu-latest
     steps:
     - uses: hashicorp/setup-terraform@v3
@@ -27,7 +27,8 @@ jobs:
     - run : terraform -chdir=./terraform/azure validate
 
   CD-deploy:
-    name: CD Deployment
+    name: Deploy
+    needs: CI-test
     runs-on: ubuntu-latest
     steps:
     - uses: hashicorp/setup-terraform@v3

--- a/terraform/azure/main.tf
+++ b/terraform/azure/main.tf
@@ -257,7 +257,7 @@ resource "azurerm_network_interface" "vm03" {
 
     ip_configuration {
         name                          = "internal"
-        subnet_id                     = azurerm_subnet.vnet.id
+        subnet_id                     = azurerm_subnet.subnet.id
         private_ip_address_allocation = "Dynamic"
     }
 }


### PR DESCRIPTION
This pull request includes updates to the CI/CD workflow configuration and a fix in the Terraform configuration for Azure resources. The most important changes are as follows:

### Workflow Configuration Updates:
* [`.github/workflows/workflow.yaml`](diffhunk://#diff-fde0e5d64aae13964fdda6d47af304cf1a7015cbc17e440ac4a5e662ee1d875eL18-R18): Renamed the `CI-test` job to `Test` and the `CD-deploy` job to `Deploy`. Additionally, added a dependency for the `Deploy` job to run after the `Test` job. [[1]](diffhunk://#diff-fde0e5d64aae13964fdda6d47af304cf1a7015cbc17e440ac4a5e662ee1d875eL18-R18) [[2]](diffhunk://#diff-fde0e5d64aae13964fdda6d47af304cf1a7015cbc17e440ac4a5e662ee1d875eL30-R31)

### Terraform Configuration Fix:
* [`terraform/azure/main.tf`](diffhunk://#diff-a72b7b93508224bfaeef0ffa2613d32b06136b4b3c4b8d7f32557def0f2e216eL260-R260): Corrected the `subnet_id` reference in the `azurerm_network_interface` resource from `azurerm_subnet.vnet.id` to `azurerm_subnet.subnet.id`.…n CI-test and CD-deploy