### PR TITLE
Refactor network interface names for virtual machines vm01 and vm02

### DIFF
--- a/terraform/azure/main.tf
+++ b/terraform/azure/main.tf
@@ -39,8 +39,8 @@ resource "azurerm_subnet_network_security_group_association" "nsg" {
     network_security_group_id = azurerm_network_security_group.nsg.id
 }
 
-resource "azurerm_network_interface" "vm01" {
-    name                = "vm01"
+resource "azurerm_network_interface" "vm01-nic" {
+    name                = "vm01-nic"
     location            = azurerm_resource_group.rg.location
     resource_group_name = azurerm_resource_group.rg.name
     ip_configuration {
@@ -50,8 +50,8 @@ resource "azurerm_network_interface" "vm01" {
     }
 }
 
-resource "azurerm_network_interface" "vm02" {
-    name                = "vm02"
+resource "azurerm_network_interface" "vm02-nic" {
+    name                = "vm02-nic"
     location            = azurerm_resource_group.rg.location
     resource_group_name = azurerm_resource_group.rg.name
     ip_configuration {
@@ -75,7 +75,7 @@ resource "azurerm_virtual_machine" "vm01" {
     name                             = "vm01"
     location                         = azurerm_resource_group.rg.location
     resource_group_name              = azurerm_resource_group.rg.name
-    network_interface_ids            = [azurerm_network_interface.vm01.id]
+    network_interface_ids            = [azurerm_network_interface.vm01-nic.id]
     availability_set_id              = azurerm_availability_set.vm.id
     vm_size                          = "Standard_DS1_v2"
     delete_os_disk_on_termination    = true
@@ -87,7 +87,7 @@ resource "azurerm_virtual_machine" "vm01" {
         version   = "latest"
     }
     storage_os_disk {
-        name              = "vm01"
+        name              = "vm01-os-disk"
         caching           = "ReadWrite"
         create_option     = "FromImage"
         managed_disk_type = "Standard_LRS"
@@ -107,7 +107,7 @@ resource "azurerm_virtual_machine" "vm02" {
     name                             = "vm02"
     location                         = azurerm_resource_group.rg.location
     resource_group_name              = azurerm_resource_group.rg.name
-    network_interface_ids            = [azurerm_network_interface.vm02.id]
+    network_interface_ids            = [azurerm_network_interface.vm02-nic.id]
     availability_set_id              = azurerm_availability_set.vm.id
     vm_size                          = "Standard_DS1_v2"
     delete_os_disk_on_termination    = true
@@ -119,7 +119,7 @@ resource "azurerm_virtual_machine" "vm02" {
         version   = "latest"
     }
     storage_os_disk {
-        name              = "vm02"
+        name              = "vm02-os-disk"
         caching           = "ReadWrite"
         create_option     = "FromImage"
         managed_disk_type = "Standard_LRS"
@@ -170,13 +170,13 @@ resource "azurerm_lb_rule" "lb" {
 
 resource "azurerm_network_interface_backend_address_pool_association" "vm01" {
     ip_configuration_name   = "vm01"
-    network_interface_id    = azurerm_network_interface.vm01.id
+    network_interface_id    = azurerm_network_interface.vm01-nic.id
     backend_address_pool_id = azurerm_lb_backend_address_pool.lb.id
 }
 
 resource "azurerm_network_interface_backend_address_pool_association" "vm02" {
     ip_configuration_name   = "vm02"
-    network_interface_id    = azurerm_network_interface.vm02.id
+    network_interface_id    = azurerm_network_interface.vm02-nic.id
     backend_address_pool_id = azurerm_lb_backend_address_pool.lb.id
 }
 
@@ -184,7 +184,7 @@ resource "azurerm_virtual_machine" "vm03" {
     name                  = "vm03"
     location              = azurerm_resource_group.rg.location
     resource_group_name   = azurerm_resource_group.rg.name
-    network_interface_ids = [azurerm_network_interface.vm03.id]
+    network_interface_ids = [azurerm_network_interface.vm03-nic.id]
     vm_size               = "Standard_DS1_v2"
 
     delete_os_disk_on_termination    = true
@@ -219,7 +219,7 @@ resource "azurerm_virtual_machine" "vm04" {
     name                  = "vm04"
     location              = azurerm_resource_group.rg.location
     resource_group_name   = azurerm_resource_group.rg.name
-    network_interface_ids = [azurerm_network_interface.vm04.id]
+    network_interface_ids = [azurerm_network_interface.vm04-nic.id]
     vm_size               = "Standard_DS1_v2"
 
     delete_os_disk_on_termination    = true
@@ -250,7 +250,7 @@ resource "azurerm_virtual_machine" "vm04" {
     }
 }
 
-resource "azurerm_network_interface" "vm03" {
+resource "azurerm_network_interface" "vm03-nic" {
     name                = "vm03-nic"
     location            = azurerm_resource_group.rg.location
     resource_group_name = azurerm_resource_group.rg.name
@@ -262,7 +262,7 @@ resource "azurerm_network_interface" "vm03" {
     }
 }
 
-resource "azurerm_network_interface" "vm04" {
+resource "azurerm_network_interface" "vm04-nic" {
     name                = "vm04-nic"
     location            = azurerm_resource_group.rg.location
     resource_group_name = azurerm_resource_group.rg.name
@@ -276,12 +276,12 @@ resource "azurerm_network_interface" "vm04" {
 
 resource "azurerm_network_interface_backend_address_pool_association" "vm03" {
     ip_configuration_name   = "internal"
-    network_interface_id    = azurerm_network_interface.vm03.id
+    network_interface_id    = azurerm_network_interface.vm03-nic.id
     backend_address_pool_id = azurerm_lb_backend_address_pool.lb.id
 }
 
 resource "azurerm_network_interface_backend_address_pool_association" "vm04" {
     ip_configuration_name   = "internal"
-    network_interface_id    = azurerm_network_interface.vm04.id
+    network_interface_id    = azurerm_network_interface.vm04-nic.id
     backend_address_pool_id = azurerm_lb_backend_address_pool.lb.id
 }


### PR DESCRIPTION
This pull request includes several changes to the `terraform/azure/main.tf` file to improve the naming consistency of network interfaces and associated resources. The most important changes include renaming network interfaces and updating references to these interfaces in virtual machines and backend address pool associations.

### Network Interface Renaming:
* Renamed `azurerm_network_interface` resources for `vm01`, `vm02`, `vm03`, and `vm04` to `vm01-nic`, `vm02-nic`, `vm03-nic`, and `vm04-nic` respectively. (`terraform/azure/main.tf`, [[1]](diffhunk://#diff-a72b7b93508224bfaeef0ffa2613d32b06136b4b3c4b8d7f32557def0f2e216eL42-R43) [[2]](diffhunk://#diff-a72b7b93508224bfaeef0ffa2613d32b06136b4b3c4b8d7f32557def0f2e216eL53-R54) [[3]](diffhunk://#diff-a72b7b93508224bfaeef0ffa2613d32b06136b4b3c4b8d7f32557def0f2e216eL253-R253) [[4]](diffhunk://#diff-a72b7b93508224bfaeef0ffa2613d32b06136b4b3c4b8d7f32557def0f2e216eL265-R265)

### Virtual Machine Updates:
* Updated `network_interface_ids` for `azurerm_virtual_machine` resources to reference the renamed network interfaces (`vm01-nic`, `vm02-nic`, `vm03-nic`, and `vm04-nic`). (`terraform/azure/main.tf`, [[1]](diffhunk://#diff-a72b7b93508224bfaeef0ffa2613d32b06136b4b3c4b8d7f32557def0f2e216eL78-R78) [[2]](diffhunk://#diff-a72b7b93508224bfaeef0ffa2613d32b06136b4b3c4b8d7f32557def0f2e216eL110-R110) [[3]](diffhunk://#diff-a72b7b93508224bfaeef0ffa2613d32b06136b4b3c4b8d7f32557def0f2e216eL173-R187) [[4]](diffhunk://#diff-a72b7b93508224bfaeef0ffa2613d32b06136b4b3c4b8d7f32557def0f2e216eL222-R222)

### Disk Naming:
* Changed `storage_os_disk` names for `vm01` and `vm02` to `vm01-os-disk` and `vm02-os-disk` respectively. (`terraform/azure/main.tf`, [[1]](diffhunk://#diff-a72b7b93508224bfaeef0ffa2613d32b06136b4b3c4b8d7f32557def0f2e216eL90-R90) [[2]](diffhunk://#diff-a72b7b93508224bfaeef0ffa2613d32b06136b4b3c4b8d7f32557def0f2e216eL122-R122)

### Backend Address Pool Association:
* Updated `network_interface_id` for backend address pool associations to reference the renamed network interfaces (`vm01-nic`, `vm02-nic`, `vm03-nic`, and `vm04-nic`). (`terraform/azure/main.tf`, [[1]](diffhunk://#diff-a72b7b93508224bfaeef0ffa2613d32b06136b4b3c4b8d7f32557def0f2e216eL173-R187) [[2]](diffhunk://#diff-a72b7b93508224bfaeef0ffa2613d32b06136b4b3c4b8d7f32557def0f2e216eL279-R285)