### PR TITLE
Refactor workflow.yaml to include Terraform initialization step

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -22,6 +22,7 @@ jobs:
       with:
         terraform_version: $TERRAFORM_VERSION
     - uses: actions/checkout@v4
+    - run : terraform -chdir=./terraform/azure init
     - run : terraform -chdir=./terraform/azure validate
 
   CD-deploy:


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/workflow.yaml` file. The change adds a step to initialize Terraform in the Azure directory before running validation.

* [`.github/workflows/workflow.yaml`](diffhunk://#diff-fde0e5d64aae13964fdda6d47af304cf1a7015cbc17e440ac4a5e662ee1d875eR25): Added a step to run `terraform -chdir=./terraform/azure init` before the validation step.