### PR TITLE
Refactor workflow.yaml to include destroy step in Terraform plan

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -35,6 +35,6 @@ jobs:
         terraform_version: $TERRAFORM_VERSION
     - uses: actions/checkout@v4
     - run : terraform -chdir=./terraform/azure init
-    - run : terraform -chdir=./terraform/azure plan -out tfplan
+    - run : terraform -chdir=./terraform/azure plan -destroy -out tfplan
     - run : terraform -chdir=./terraform/azure apply tfplan
     - run : terraform -chdir=./terraform/azure show


### PR DESCRIPTION
This pull request includes a small but significant change to the Terraform workflow in the GitHub Actions configuration file. The change modifies the Terraform plan command to include the `-destroy` flag, which will plan the destruction of resources instead of creating or updating them.

* [`.github/workflows/workflow.yaml`](diffhunk://#diff-fde0e5d64aae13964fdda6d47af304cf1a7015cbc17e440ac4a5e662ee1d875eL38-R38): Changed the Terraform plan command to use the `-destroy` flag, ensuring that the plan will prepare for resource destruction instead of creation.