### PR TITLE
Refactor workflow.yaml to include Terraform plan without destroy step

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -35,6 +35,6 @@ jobs:
         terraform_version: $TERRAFORM_VERSION
     - uses: actions/checkout@v4
     - run : terraform -chdir=./terraform/azure init
-    - run : terraform -chdir=./terraform/azure plan -destroy -out tfplan
+    - run : terraform -chdir=./terraform/azure plan -out tfplan
     - run : terraform -chdir=./terraform/azure apply tfplan
     - run : terraform -chdir=./terraform/azure show


### PR DESCRIPTION
This pull request includes a small but significant change to the Terraform workflow configuration in the `.github/workflows/workflow.yaml` file. The change modifies the Terraform plan command to remove the `-destroy` option, which will now create a standard plan instead of a plan to destroy resources.

* `jobs:` in `.github/workflows/workflow.yaml`: Modified the Terraform plan command to remove the `-destroy` option, changing it from a destroy plan to a standard plan.