### PR TITLE
Fix Terraform Show step in workflow.yaml and remove redundant Load Ba…

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -44,6 +44,3 @@ jobs:
       run : terraform -chdir=./terraform/azure apply tfplan
     - name: Terraform Show
       run : terraform -chdir=./terraform/azure show
-    - name: Load Balancer url
-      run: |
-        echo "LB_URL=$(terraform -chdir=./terraform/azure output -raw lb_fqdn)"


### PR DESCRIPTION
This pull request modifies the Terraform workflow in the GitHub Actions configuration by removing an unused step related to the load balancer URL.

### Workflow simplification:
* [`.github/workflows/workflow.yaml`](diffhunk://#diff-fde0e5d64aae13964fdda6d47af304cf1a7015cbc17e440ac4a5e662ee1d875eL47-L49): Removed the "Load Balancer url" step, which extracted the load balancer's fully qualified domain name (`lb_fqdn`) from Terraform outputs. This step was deemed unnecessary.…lancer URL step