### PR TITLE
Remove destroy option from Terraform Plan command and add static publ…

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -39,7 +39,7 @@ jobs:
     - name: Terraform Init
       run : terraform -chdir=./terraform/azure init
     - name: Terraform Plan
-      run : terraform -chdir=./terraform/azure plan -destroy -out tfplan
+      run : terraform -chdir=./terraform/azure plan -out tfplan
     - name: Terraform Apply
       run : terraform -chdir=./terraform/azure apply tfplan
     - name: Terraform Show

--- a/terraform/azure/main.tf
+++ b/terraform/azure/main.tf
@@ -45,6 +45,14 @@ resource "azurerm_subnet_network_security_group_association" "nsg" {
   network_security_group_id = azurerm_network_security_group.nsg.id
 }
 
+resource "azurerm_public_ip" "vm01" {
+  name                = "vm01-ip"
+  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
+  allocation_method   = "Static"
+  sku                 = "Basic"
+}
+
 resource "azurerm_network_interface" "vm01-nic" {
   name                = "vm01-nic"
   location            = azurerm_resource_group.rg.location
@@ -53,6 +61,7 @@ resource "azurerm_network_interface" "vm01-nic" {
     name                          = "vm01"
     subnet_id                     = azurerm_subnet.subnet.id
     private_ip_address_allocation = "Dynamic"
+    public_ip_address_id          = azurerm_public_ip.vm01.id
   }
 }
 


### PR DESCRIPTION
This pull request includes updates to the Terraform configuration and GitHub Actions workflow. The most important changes involve modifying the Terraform plan command to remove the `-destroy` flag, adding a new public IP resource, and associating it with a network interface.

### Workflow updates:

* [`.github/workflows/workflow.yaml`](diffhunk://#diff-fde0e5d64aae13964fdda6d47af304cf1a7015cbc17e440ac4a5e662ee1d875eL42-R42): Updated the Terraform plan command by removing the `-destroy` flag, ensuring the plan does not default to a destroy operation.

### Terraform configuration updates:

* [`terraform/azure/main.tf`](diffhunk://#diff-a72b7b93508224bfaeef0ffa2613d32b06136b4b3c4b8d7f32557def0f2e216eR48-R55): Added a new `azurerm_public_ip` resource for `vm01` with static allocation and a basic SKU. This ensures the virtual machine has a public IP address.
* [`terraform/azure/main.tf`](diffhunk://#diff-a72b7b93508224bfaeef0ffa2613d32b06136b4b3c4b8d7f32557def0f2e216eR64): Updated the `azurerm_network_interface` resource for `vm01` to associate it with the newly created public IP address.