### PR TITLE
Update SKU for public IP resources to Standard for improved performance

### DIFF
--- a/terraform/azure/main.tf
+++ b/terraform/azure/main.tf
@@ -50,7 +50,7 @@ resource "azurerm_public_ip" "vm01" {
   location            = azurerm_resource_group.rg.location
   resource_group_name = azurerm_resource_group.rg.name
   allocation_method   = "Static"
-  sku                 = "Basic"
+  sku                 = "Standard"
 }
 
 resource "azurerm_network_interface" "vm01-nic" {
@@ -156,12 +156,14 @@ resource "azurerm_public_ip" "lb" {
   resource_group_name = azurerm_resource_group.rg.name
   allocation_method   = "Static"
   domain_name_label   = "staticsitelbtf0001"
+  sku                 = "Standard"
 }
 
 resource "azurerm_lb" "lb" {
   name                = "lb"
   location            = azurerm_resource_group.rg.location
   resource_group_name = azurerm_resource_group.rg.name
+  sku                 = "Standard"
   frontend_ip_configuration {
     name                 = "lb"
     public_ip_address_id = azurerm_public_ip.lb.id


### PR DESCRIPTION
This pull request includes updates to the Azure Terraform configuration to enhance the reliability and scalability of resources by upgrading the SKU of public IPs and the load balancer from "Basic" to "Standard".

### Azure Terraform Configuration Updates:

* Changed the `sku` of the `azurerm_public_ip` resource for `vm01` from "Basic" to "Standard" to improve reliability and support for advanced networking features. (`terraform/azure/main.tf`, [terraform/azure/main.tfL53-R53](diffhunk://#diff-a72b7b93508224bfaeef0ffa2613d32b06136b4b3c4b8d7f32557def0f2e216eL53-R53))
* Added the `sku` attribute with a value of "Standard" to the `azurerm_public_ip` resource for the load balancer (`lb`) to ensure consistency with the upgraded load balancer configuration. (`terraform/azure/main.tf`, [terraform/azure/main.tfR159-R166](diffhunk://#diff-a72b7b93508224bfaeef0ffa2613d32b06136b4b3c4b8d7f32557def0f2e216eR159-R166))
* Upgraded the `sku` of the `azurerm_lb` resource to "Standard" to leverage advanced features such as zone redundancy and higher availability. (`terraform/azure/main.tf`, [terraform/azure/main.tfR159-R166](diffhunk://#diff-a72b7b93508224bfaeef0ffa2613d32b06136b4b3c4b8d7f32557def0f2e216eR159-R166))