### PR TITLE
Add destroy option to Terraform Plan command in workflow.yaml

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -39,7 +39,7 @@ jobs:
     - name: Terraform Init
       run : terraform -chdir=./terraform/azure init
     - name: Terraform Plan
-      run : terraform -chdir=./terraform/azure plan -out tfplan
+      run : terraform -chdir=./terraform/azure plan -destroy -out tfplan
     - name: Terraform Apply
       run : terraform -chdir=./terraform/azure apply tfplan
     - name: Terraform Show


### PR DESCRIPTION
This pull request modifies the Terraform workflow in the GitHub Actions configuration to change the behavior of the `Terraform Plan` step.

### Workflow Configuration Changes:

* [`.github/workflows/workflow.yaml`](diffhunk://#diff-fde0e5d64aae13964fdda6d47af304cf1a7015cbc17e440ac4a5e662ee1d875eL42-R42): Updated the `Terraform Plan` step to use the `-destroy` flag, indicating that the plan will now focus on destroying resources instead of creating or modifying them.