### PR TITLE
Remove destroy option from Terraform Plan command in workflow.yaml

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -39,7 +39,7 @@ jobs:
     - name: Terraform Init
       run : terraform -chdir=./terraform/azure init
     - name: Terraform Plan
-      run : terraform -chdir=./terraform/azure plan -destroy -out tfplan
+      run : terraform -chdir=./terraform/azure plan -out tfplan
     - name: Terraform Apply
       run : terraform -chdir=./terraform/azure apply tfplan
     - name: Terraform Show

--- a/terraform/azure/main.tf
+++ b/terraform/azure/main.tf
@@ -65,16 +65,16 @@ resource "azurerm_network_interface" "vm01-nic" {
   }
 }
 
-resource "azurerm_network_interface" "vm02-nic" {
-  name                = "vm02-nic"
-  location            = azurerm_resource_group.rg.location
-  resource_group_name = azurerm_resource_group.rg.name
-  ip_configuration {
-    name                          = "vm02"
-    subnet_id                     = azurerm_subnet.subnet.id
-    private_ip_address_allocation = "Dynamic"
-  }
-}
+# resource "azurerm_network_interface" "vm02-nic" {
+#   name                = "vm02-nic"
+#   location            = azurerm_resource_group.rg.location
+#   resource_group_name = azurerm_resource_group.rg.name
+#   ip_configuration {
+#     name                          = "vm02"
+#     subnet_id                     = azurerm_subnet.subnet.id
+#     private_ip_address_allocation = "Dynamic"
+#   }
+# }
 
 data "template_file" "cloud_init" {
   template = file("./scripts/cloud_init.sh")
@@ -118,81 +118,81 @@ resource "azurerm_virtual_machine" "vm01" {
   }
 }
 
-resource "azurerm_virtual_machine" "vm02" {
-  name                             = "vm02"
-  location                         = azurerm_resource_group.rg.location
-  resource_group_name              = azurerm_resource_group.rg.name
-  network_interface_ids            = [azurerm_network_interface.vm02-nic.id]
-  availability_set_id              = azurerm_availability_set.vm.id
-  vm_size                          = "Standard_D2s_v3"
-  delete_os_disk_on_termination    = true
-  delete_data_disks_on_termination = true
-  storage_image_reference {
-    publisher = "Canonical"
-    offer     = "0001-com-ubuntu-server-jammy"
-    sku       = "22_04-lts"
-    version   = "latest"
-  }
-  storage_os_disk {
-    name              = "vm02-os-disk"
-    caching           = "ReadWrite"
-    create_option     = "FromImage"
-    managed_disk_type = "Standard_LRS"
-  }
-  os_profile {
-    computer_name  = "vm02"
-    admin_username = "vmuser"
-    admin_password = "Password1234!"
-    custom_data    = base64encode(data.template_file.cloud_init.rendered)
-  }
-  os_profile_linux_config {
-    disable_password_authentication = false
-  }
-}
+# resource "azurerm_virtual_machine" "vm02" {
+#   name                             = "vm02"
+#   location                         = azurerm_resource_group.rg.location
+#   resource_group_name              = azurerm_resource_group.rg.name
+#   network_interface_ids            = [azurerm_network_interface.vm02-nic.id]
+#   availability_set_id              = azurerm_availability_set.vm.id
+#   vm_size                          = "Standard_D2s_v3"
+#   delete_os_disk_on_termination    = true
+#   delete_data_disks_on_termination = true
+#   storage_image_reference {
+#     publisher = "Canonical"
+#     offer     = "0001-com-ubuntu-server-jammy"
+#     sku       = "22_04-lts"
+#     version   = "latest"
+#   }
+#   storage_os_disk {
+#     name              = "vm02-os-disk"
+#     caching           = "ReadWrite"
+#     create_option     = "FromImage"
+#     managed_disk_type = "Standard_LRS"
+#   }
+#   os_profile {
+#     computer_name  = "vm02"
+#     admin_username = "vmuser"
+#     admin_password = "Password1234!"
+#     custom_data    = base64encode(data.template_file.cloud_init.rendered)
+#   }
+#   os_profile_linux_config {
+#     disable_password_authentication = false
+#   }
+# }
 
-resource "azurerm_public_ip" "lb" {
-  name                = "lb"
-  location            = azurerm_resource_group.rg.location
-  resource_group_name = azurerm_resource_group.rg.name
-  allocation_method   = "Static"
-  domain_name_label   = "staticsitelbtf0001"
-  sku                 = "Standard"
-}
+# resource "azurerm_public_ip" "lb" {
+#   name                = "lb"
+#   location            = azurerm_resource_group.rg.location
+#   resource_group_name = azurerm_resource_group.rg.name
+#   allocation_method   = "Static"
+#   domain_name_label   = "staticsitelbtf0001"
+#   sku                 = "Standard"
+# }
 
-resource "azurerm_lb" "lb" {
-  name                = "lb"
-  location            = azurerm_resource_group.rg.location
-  resource_group_name = azurerm_resource_group.rg.name
-  sku                 = "Standard"
-  frontend_ip_configuration {
-    name                 = "lb"
-    public_ip_address_id = azurerm_public_ip.lb.id
-  }
-}
+# resource "azurerm_lb" "lb" {
+#   name                = "lb"
+#   location            = azurerm_resource_group.rg.location
+#   resource_group_name = azurerm_resource_group.rg.name
+#   sku                 = "Standard"
+#   frontend_ip_configuration {
+#     name                 = "lb"
+#     public_ip_address_id = azurerm_public_ip.lb.id
+#   }
+# }
 
-resource "azurerm_lb_backend_address_pool" "lb" {
-  name            = "lb"
-  loadbalancer_id = azurerm_lb.lb.id
-}
+# resource "azurerm_lb_backend_address_pool" "lb" {
+#   name            = "lb"
+#   loadbalancer_id = azurerm_lb.lb.id
+# }
 
-resource "azurerm_lb_rule" "lb" {
-  name                           = "HTTP"
-  loadbalancer_id                = azurerm_lb.lb.id
-  protocol                       = "Tcp"
-  frontend_port                  = 80
-  backend_port                   = 80
-  frontend_ip_configuration_name = "lb"
-  backend_address_pool_ids       = [azurerm_lb_backend_address_pool.lb.id]
-}
+# resource "azurerm_lb_rule" "lb" {
+#   name                           = "HTTP"
+#   loadbalancer_id                = azurerm_lb.lb.id
+#   protocol                       = "Tcp"
+#   frontend_port                  = 80
+#   backend_port                   = 80
+#   frontend_ip_configuration_name = "lb"
+#   backend_address_pool_ids       = [azurerm_lb_backend_address_pool.lb.id]
+# }
 
-resource "azurerm_network_interface_backend_address_pool_association" "vm01" {
-  ip_configuration_name   = "vm01"
-  network_interface_id    = azurerm_network_interface.vm01-nic.id
-  backend_address_pool_id = azurerm_lb_backend_address_pool.lb.id
-}
+# resource "azurerm_network_interface_backend_address_pool_association" "vm01" {
+#   ip_configuration_name   = "vm01"
+#   network_interface_id    = azurerm_network_interface.vm01-nic.id
+#   backend_address_pool_id = azurerm_lb_backend_address_pool.lb.id
+# }
 
-resource "azurerm_network_interface_backend_address_pool_association" "vm02" {
-  ip_configuration_name   = "vm02"
-  network_interface_id    = azurerm_network_interface.vm02-nic.id
-  backend_address_pool_id = azurerm_lb_backend_address_pool.lb.id
-}
+# resource "azurerm_network_interface_backend_address_pool_association" "vm02" {
+#   ip_configuration_name   = "vm02"
+#   network_interface_id    = azurerm_network_interface.vm02-nic.id
+#   backend_address_pool_id = azurerm_lb_backend_address_pool.lb.id
+# }


### PR DESCRIPTION
This pull request includes changes to streamline the Terraform configuration by commenting out resources related to a second virtual machine (`vm02`) and its associated load balancer setup. Additionally, it modifies the Terraform workflow to remove the `-destroy` flag from the `plan` command. Below are the most important changes grouped by theme:

### Terraform Workflow Update:
* The `Terraform Plan` step in `.github/workflows/workflow.yaml` was updated to remove the `-destroy` flag, ensuring the plan focuses on creating or updating resources rather than planning for destruction. (`[.github/workflows/workflow.yamlL42-R42](diffhunk://#diff-fde0e5d64aae13964fdda6d47af304cf1a7015cbc17e440ac4a5e662ee1d875eL42-R42)`)

### Terraform Resource Adjustments:
* The `azurerm_network_interface` resource for `vm02` was commented out in `terraform/azure/main.tf`, effectively disabling its creation. (`[terraform/azure/main.tfL68-R77](diffhunk://#diff-a72b7b93508224bfaeef0ffa2613d32b06136b4b3c4b8d7f32557def0f2e216eL68-R77)`)
* The `azurerm_virtual_machine` resource for `vm02` was commented out, along with its associated configuration, such as OS disk, network interface, and Linux profile. (`[terraform/azure/main.tfL121-R198](diffhunk://#diff-a72b7b93508224bfaeef0ffa2613d32b06136b4b3c4b8d7f32557def0f2e216eL121-R198)`)
* Resources related to the load balancer (`azurerm_public_ip`, `azurerm_lb`, `azurerm_lb_backend_address_pool`, `azurerm_lb_rule`, and backend address pool associations) were commented out, disabling the load balancer setup. (`[terraform/azure/main.tfL121-R198](diffhunk://#diff-a72b7b93508224bfaeef0ffa2613d32b06136b4b3c4b8d7f32557def0f2e216eL121-R198)`)