### PR TITLE
Comment out Load Balancer FQDN output in Terraform configuration

### DIFF
--- a/terraform/azure/output.tf
+++ b/terraform/azure/output.tf
@@ -1,4 +1,4 @@
-output "lb_fqdn" {
-  value       = "http://${azurerm_public_ip.lb.fqdn}"
-  description = "FQDN público do Load Balancer"
-}
+# output "lb_fqdn" {
+#   value       = "http://${azurerm_public_ip.lb.fqdn}"
+#   description = "FQDN público do Load Balancer"
+# }


### PR DESCRIPTION
This pull request includes a minor change to the `terraform/azure/output.tf` file. The change comments out the `lb_fqdn` output block, effectively disabling the output of the public FQDN for the Load Balancer.