### PR TITLE
Update network security group rules to allow HTTPS traffic and retain…

### DIFF
--- a/terraform/azure/main.tf
+++ b/terraform/azure/main.tf
@@ -28,8 +28,19 @@ resource "azurerm_network_security_group" "nsg" {
     destination_address_prefix = "*"
   }
   security_rule {
-    name                       = "SSH"
+    name                       = "HTTPS"
     priority                   = 1002
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "443"
+    source_address_prefix      = "*"
+    destination_address_prefix = "*"
+  }
+  security_rule {
+    name                       = "SSH"
+    priority                   = 1003
     direction                  = "Inbound"
     access                     = "Allow"
     protocol                   = "Tcp"


### PR DESCRIPTION
This pull request updates the network security group configuration in the `terraform/azure/main.tf` file to improve security and support HTTPS traffic. The key changes involve modifying an existing rule and adding a new one.

### Changes to network security group configuration:

* Updated the existing security rule:
  - Renamed the rule from "SSH" to "HTTPS."
  - Changed the destination port range to `443` to allow HTTPS traffic.

* Added a new security rule:
  - Reintroduced the "SSH" rule with a new priority (`1003`) to allow SSH traffic on port `22`.