### PR TITLE
Update Ubuntu image offer and SKU for virtual machine configuration

### DIFF
--- a/terraform/azure/main.tf
+++ b/terraform/azure/main.tf
@@ -108,8 +108,8 @@ resource "azurerm_virtual_machine" "vm01" {
   delete_data_disks_on_termination = true
   storage_image_reference {
     publisher = "Canonical"
-    offer     = "0001-com-ubuntu-server-jammy"
-    sku       = "22_04-lts"
+    offer     = "ubuntu-24_04-lts"
+    sku       = "server"
     version   = "latest"
   }
   storage_os_disk {


### PR DESCRIPTION
This pull request updates the configuration for an Azure virtual machine in the Terraform file to use a newer version of Ubuntu. The most significant change is the update to the `storage_image_reference` block.

### Virtual Machine Configuration Updates:
* Updated the `offer` value from `"0001-com-ubuntu-server-jammy"` to `"ubuntu-24_04-lts"` to use the latest Ubuntu LTS version.
* Updated the `sku` value from `"22_04-lts"` to `"server"` to align with the new offer.