### PR TITLE
Update vm02 public IP allocation method to Static

### DIFF
--- a/terraform/azure/main.tf
+++ b/terraform/azure/main.tf
@@ -69,7 +69,7 @@ resource "azurerm_public_ip" "vm02" {
   name                = "vm02-ip"
   location            = azurerm_resource_group.rg.location
   resource_group_name = azurerm_resource_group.rg.name
-  allocation_method   = "Dynamic"
+  allocation_method   = "Static"
   sku                 = "Standard"
 }
 


### PR DESCRIPTION
This pull request includes a small but significant change to the `terraform/azure/main.tf` file. The allocation method for the `azurerm_public_ip` resource named `vm02` has been updated from `Dynamic` to `Static`.