### PR TITLE
Develop

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -39,7 +39,7 @@ jobs:
     - name: Terraform Init
       run : terraform -chdir=./terraform/azure init
     - name: Terraform Plan
-      run : terraform -chdir=./terraform/azure plan -out tfplan
+      run : terraform -chdir=./terraform/azure plan -destroy -out tfplan
     - name: Terraform Apply
       run : terraform -chdir=./terraform/azure apply tfplan
     - name: Terraform Show

--- a/terraform/azure/scripts/cloud_init.sh
+++ b/terraform/azure/scripts/cloud_init.sh
@@ -8,3 +8,4 @@ echo "Deploy PHP info app"
 cd /tmp
 git clone https://github.com/kledsonhugo/app-dynamicsite
 cp /tmp/app-dynamicsite/phpinfo.php /var/www/html/index.php
+sudo rm /var/www/html/index.html


### PR DESCRIPTION
This pull request makes changes to the Terraform workflow and the cloud initialization script. The most significant updates include switching the Terraform plan command to a destroy plan and removing the default `index.html` file during the deployment of a PHP info app.

### Workflow changes:
* [`.github/workflows/workflow.yaml`](diffhunk://#diff-fde0e5d64aae13964fdda6d47af304cf1a7015cbc17e440ac4a5e662ee1d875eL42-R42): Updated the Terraform plan command to use the `-destroy` flag, which generates a plan to destroy resources instead of creating them.

### Deployment script changes:
* [`terraform/azure/scripts/cloud_init.sh`](diffhunk://#diff-f4a4ad4eb7a4c0f0c47016cbd745e7c4e869a4c2c767394d692c2eb4f68ea44bR11): Added a command to remove the default `index.html` file from `/var/www/html` to ensure the `index.php` file is served correctly.