### PR TITLE
Remove destroy option from Terraform Plan step

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -39,7 +39,7 @@ jobs:
     - name: Terraform Init
       run : terraform -chdir=./terraform/azure init
     - name: Terraform Plan
-      run : terraform -chdir=./terraform/azure plan -destroy -out tfplan
+      run : terraform -chdir=./terraform/azure plan -out tfplan
     - name: Terraform Apply
       run : terraform -chdir=./terraform/azure apply tfplan
     - name: Terraform Show


### PR DESCRIPTION
This pull request makes a minor adjustment to the Terraform workflow in the GitHub Actions configuration. The change removes the `-destroy` flag from the `terraform plan` command, ensuring that the plan operation no longer targets resource destruction.

* [`.github/workflows/workflow.yaml`](diffhunk://#diff-fde0e5d64aae13964fdda6d47af304cf1a7015cbc17e440ac4a5e662ee1d875eL42-R42): Updated the `Terraform Plan` step to remove the `-destroy` flag from the command, aligning it with standard plan operations.