### PR TITLE
Atualizar etapa Terraform Plan para incluir opção -destroy

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -39,7 +39,7 @@ jobs:
     - name: Terraform Init
       run : terraform -chdir=./terraform/azure init
     - name: Terraform Plan
-      run : terraform -chdir=./terraform/azure plan -out tfplan
+      run : terraform -chdir=./terraform/azure plan -destroy -out tfplan
     - name: Terraform Apply
       run : terraform -chdir=./terraform/azure apply tfplan
     - name: Terraform Show

--- a/ISSUE_TEMPLATE/bug_report.yaml
+++ b/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,0 +1,47 @@
+name: Bug Report
+description: Reportar um problema no sistema
+title: "[BUG] "
+labels: [bug]
+assignees: []
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Obrigado por contribuir! Por favor, preencha as informações abaixo para nos ajudar a reproduzir e corrigir o problema.
+
+  - type: input
+    id: sistema
+    attributes:
+      label: Em qual sistema ocorreu?
+      placeholder: "Ex: dashboard-admin, api-auth..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Passos para reproduzir
+      description: "Liste passo a passo como reproduzir o problema"
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Resultado esperado
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Resultado atual
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Contexto adicional
+      description: Inclua capturas de tela, links, logs, etc.


### PR DESCRIPTION
This pull request modifies the Terraform workflow in the GitHub Actions configuration to use the `-destroy` flag during the planning stage. This change ensures that the Terraform plan is created with the intent to destroy resources.

* [`.github/workflows/workflow.yaml`](diffhunk://#diff-fde0e5d64aae13964fdda6d47af304cf1a7015cbc17e440ac4a5e662ee1d875eL42-R42): Updated the `Terraform Plan` step to include the `-destroy` flag, which generates a plan for destroying resources instead of creating or modifying them.