### PR TITLE
Atualizar prioridades das regras de segurança para o grupo de seguran…

### DIFF
--- a/terraform/azure/main.tf
+++ b/terraform/azure/main.tf
@@ -18,7 +18,7 @@ resource "azurerm_network_security_group" "nsg" {
   resource_group_name = azurerm_resource_group.rg.name
   security_rule {
     name                       = "HTTP"
-    priority                   = 1001
+    priority                   = 1010
     direction                  = "Inbound"
     access                     = "Allow"
     protocol                   = "Tcp"
@@ -29,7 +29,7 @@ resource "azurerm_network_security_group" "nsg" {
   }
   security_rule {
     name                       = "SSH"
-    priority                   = 1003
+    priority                   = 1020
     direction                  = "Inbound"
     access                     = "Allow"
     protocol                   = "Tcp"


### PR DESCRIPTION
This pull request updates the priority values of security rules in the `azurerm_network_security_group` resource to ensure proper ordering and avoid conflicts.

Changes to security rule priorities:

* [`terraform/azure/main.tf`](diffhunk://#diff-a72b7b93508224bfaeef0ffa2613d32b06136b4b3c4b8d7f32557def0f2e216eL21-R21): Updated the priority of the "HTTP" security rule from `1001` to `1010`.
* [`terraform/azure/main.tf`](diffhunk://#diff-a72b7b93508224bfaeef0ffa2613d32b06136b4b3c4b8d7f32557def0f2e216eL32-R32): Updated the priority of the "SSH" security rule from `1003` to `1020`.