### PR TITLE
Adicionar configuração do Load Balancer e atualizar saída FQDN no Ter…

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -39,7 +39,7 @@ jobs:
     - name: Terraform Init
       run : terraform -chdir=./terraform/azure init
     - name: Terraform Plan
-      run : terraform -chdir=./terraform/azure plan -destroy -out tfplan
+      run : terraform -chdir=./terraform/azure plan -out tfplan
     - name: Terraform Apply
       run : terraform -chdir=./terraform/azure apply tfplan
     - name: Terraform Show

--- a/terraform/azure/main.tf
+++ b/terraform/azure/main.tf
@@ -159,49 +159,49 @@ resource "azurerm_virtual_machine" "vm02" {
   }
 }
 
-# resource "azurerm_public_ip" "lb" {
-#   name                = "lb"
-#   location            = azurerm_resource_group.rg.location
-#   resource_group_name = azurerm_resource_group.rg.name
-#   allocation_method   = "Static"
-#   domain_name_label   = "staticsitelbtf0001"
-#   sku                 = "Standard"
-# }
+resource "azurerm_public_ip" "lb" {
+  name                = "lb"
+  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
+  allocation_method   = "Static"
+  domain_name_label   = "staticsitelbtf0001"
+  sku                 = "Standard"
+}
 
-# resource "azurerm_lb" "lb" {
-#   name                = "lb"
-#   location            = azurerm_resource_group.rg.location
-#   resource_group_name = azurerm_resource_group.rg.name
-#   sku                 = "Standard"
-#   frontend_ip_configuration {
-#     name                 = "lb"
-#     public_ip_address_id = azurerm_public_ip.lb.id
-#   }
-# }
+resource "azurerm_lb" "lb" {
+  name                = "lb"
+  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
+  sku                 = "Standard"
+  frontend_ip_configuration {
+    name                 = "lb"
+    public_ip_address_id = azurerm_public_ip.lb.id
+  }
+}
 
-# resource "azurerm_lb_backend_address_pool" "lb" {
-#   name            = "lb"
-#   loadbalancer_id = azurerm_lb.lb.id
-# }
+resource "azurerm_lb_backend_address_pool" "lb" {
+  name            = "lb"
+  loadbalancer_id = azurerm_lb.lb.id
+}
 
-# resource "azurerm_lb_rule" "lb" {
-#   name                           = "HTTP"
-#   loadbalancer_id                = azurerm_lb.lb.id
-#   protocol                       = "Tcp"
-#   frontend_port                  = 80
-#   backend_port                   = 80
-#   frontend_ip_configuration_name = "lb"
-#   backend_address_pool_ids       = [azurerm_lb_backend_address_pool.lb.id]
-# }
+resource "azurerm_lb_rule" "lb" {
+  name                           = "HTTP"
+  loadbalancer_id                = azurerm_lb.lb.id
+  protocol                       = "Tcp"
+  frontend_port                  = 80
+  backend_port                   = 80
+  frontend_ip_configuration_name = "lb"
+  backend_address_pool_ids       = [azurerm_lb_backend_address_pool.lb.id]
+}
 
-# resource "azurerm_network_interface_backend_address_pool_association" "vm01" {
-#   ip_configuration_name   = "vm01"
-#   network_interface_id    = azurerm_network_interface.vm01-nic.id
-#   backend_address_pool_id = azurerm_lb_backend_address_pool.lb.id
-# }
+resource "azurerm_network_interface_backend_address_pool_association" "vm01" {
+  ip_configuration_name   = "vm01"
+  network_interface_id    = azurerm_network_interface.vm01-nic.id
+  backend_address_pool_id = azurerm_lb_backend_address_pool.lb.id
+}
 
-# resource "azurerm_network_interface_backend_address_pool_association" "vm02" {
-#   ip_configuration_name   = "vm02"
-#   network_interface_id    = azurerm_network_interface.vm02-nic.id
-#   backend_address_pool_id = azurerm_lb_backend_address_pool.lb.id
-# }
+resource "azurerm_network_interface_backend_address_pool_association" "vm02" {
+  ip_configuration_name   = "vm02"
+  network_interface_id    = azurerm_network_interface.vm02-nic.id
+  backend_address_pool_id = azurerm_lb_backend_address_pool.lb.id
+}

--- a/terraform/azure/output.tf
+++ b/terraform/azure/output.tf
@@ -1,4 +1,4 @@
-# output "lb_fqdn" {
-#   value       = "http://${azurerm_public_ip.lb.fqdn}"
-#   description = "FQDN público do Load Balancer"
-# }
+output "lb_fqdn" {
+  value       = "http://${azurerm_public_ip.lb.fqdn}"
+  description = "FQDN público do Load Balancer"
+}


### PR DESCRIPTION
This pull request includes updates to the Terraform configuration and workflow files, focusing on enabling a load balancer setup and refining the Terraform workflow. The most important changes include reintroducing and enabling resources for an Azure Load Balancer, modifying the Terraform plan command to remove the `-destroy` flag, and reactivating the output for the load balancer's FQDN.

### Terraform Configuration Updates:

* Re-enabled and configured resources for an Azure Load Balancer, including public IP, load balancer, backend address pool, load balancer rule, and network interface backend address pool associations. These were previously commented out and are now active. (`terraform/azure/main.tf`, [terraform/azure/main.tfL162-R207](diffhunk://#diff-a72b7b93508224bfaeef0ffa2613d32b06136b4b3c4b8d7f32557def0f2e216eL162-R207))
* Reactivated the `lb_fqdn` output to provide the public FQDN of the Load Balancer. This output was previously commented out. (`terraform/azure/output.tf`, [terraform/azure/output.tfL1-R4](diffhunk://#diff-5010354209923ed49f259468ac14b811ad044189bf5268caa6179ff03fa37738L1-R4))

### Workflow Updates:

* Modified the Terraform plan command in `.github/workflows/workflow.yaml` to remove the `-destroy` flag, ensuring the plan does not default to a destroy operation. (`.github/workflows/workflow.yaml`, [.github/workflows/workflow.yamlL42-R42](diffhunk://#diff-fde0e5d64aae13964fdda6d47af304cf1a7015cbc17e440ac4a5e662ee1d875eL42-R42))