### PR TITLE
Adicionar distribuição de carga padrão à regra do Load Balancer e atu…

### DIFF
--- a/terraform/azure/main.tf
+++ b/terraform/azure/main.tf
@@ -192,6 +192,7 @@ resource "azurerm_lb_rule" "lb" {
   backend_port                   = 80
   frontend_ip_configuration_name = "lb"
   backend_address_pool_ids       = [azurerm_lb_backend_address_pool.lb.id]
+  load_distribution              = "Default"
 }
 
 resource "azurerm_network_interface_backend_address_pool_association" "vm01" {

--- a/terraform/azure/provider.tf
+++ b/terraform/azure/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 4.26.0"
+      version = ">= 4.28.0"
     }
   }
   backend "azurerm" {


### PR DESCRIPTION
This pull request updates the Azure Terraform configuration to enhance load balancer functionality and ensure compatibility with the latest provider version. The most important changes are outlined below:

### Load Balancer Configuration Updates:
* [`terraform/azure/main.tf`](diffhunk://#diff-a72b7b93508224bfaeef0ffa2613d32b06136b4b3c4b8d7f32557def0f2e216eR195): Added the `load_distribution` property to the `azurerm_lb_rule` resource, setting it to `"Default"` to specify the load distribution policy.

### Provider Version Update:
* [`terraform/azure/provider.tf`](diffhunk://#diff-e6a6a136cfe0d652b2d2f4ad79cc3f05261fd9e3da765e1712e59bcc8f698f01L5-R5): Updated the required version of the `azurerm` provider from `>= 4.26.0` to `>= 4.28.0` to leverage new features and improvements.