### PR TITLE
Adicionar probe HTTP ao Load Balancer com configuração de verificação…

### DIFF
--- a/terraform/azure/main.tf
+++ b/terraform/azure/main.tf
@@ -184,6 +184,16 @@ resource "azurerm_lb_backend_address_pool" "lb" {
   loadbalancer_id = azurerm_lb.lb.id
 }
 
+resource "azurerm_lb_probe" "http" {
+  name                = "http-probe"
+  resource_group_name = azurerm_resource_group.rg.name
+  loadbalancer_id     = azurerm_lb.lb.id
+  protocol            = "Tcp"
+  port                = 80
+  interval_in_seconds = 5
+  number_of_probes    = 2
+}
+
 resource "azurerm_lb_rule" "lb" {
   name                           = "HTTP"
   loadbalancer_id                = azurerm_lb.lb.id
@@ -192,6 +202,7 @@ resource "azurerm_lb_rule" "lb" {
   backend_port                   = 80
   frontend_ip_configuration_name = "lb"
   backend_address_pool_ids       = [azurerm_lb_backend_address_pool.lb.id]
+  probe_id                       = azurerm_lb_probe.http.id
   load_distribution              = "Default"
 }
 


### PR DESCRIPTION
This pull request introduces a health probe configuration for an Azure Load Balancer to improve monitoring and ensure traffic is routed only to healthy backend instances. The changes include adding a new `azurerm_lb_probe` resource and integrating it with the existing load balancer rule.

### Load Balancer Health Probe Configuration:

* **Added a new health probe resource**: Introduced the `azurerm_lb_probe` resource to define an HTTP probe with a TCP protocol on port 80, a 5-second interval, and 2 probe attempts before marking a backend as unhealthy. (`terraform/azure/main.tf`, [terraform/azure/main.tfR187-R196](diffhunk://#diff-a72b7b93508224bfaeef0ffa2613d32b06136b4b3c4b8d7f32557def0f2e216eR187-R196))

* **Integrated the health probe with the load balancer rule**: Updated the `azurerm_lb_rule` resource to reference the newly created health probe using the `probe_id` property. This ensures the load balancer uses the probe to monitor backend health. (`terraform/azure/main.tf`, [terraform/azure/main.tfR205](diffhunk://#diff-a72b7b93508224bfaeef0ffa2613d32b06136b4b3c4b8d7f32557def0f2e216eR205))