### PR TITLE
Remover referência ao grupo de recursos no probe HTTP do Load Balancer

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
     - main
+    - develop
 
 env:
   TERRAFORM_VERSION  : 1.11.3
@@ -29,6 +30,7 @@ jobs:
     name: Deploy
     needs: CI-test
     runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
     steps:
     - name: Terraform Setup
       uses: hashicorp/setup-terraform@v3

--- a/terraform/azure/main.tf
+++ b/terraform/azure/main.tf
@@ -186,7 +186,6 @@ resource "azurerm_lb_backend_address_pool" "lb" {
 
 resource "azurerm_lb_probe" "http" {
   name                = "http-probe"
-  resource_group_name = azurerm_resource_group.rg.name
   loadbalancer_id     = azurerm_lb.lb.id
   protocol            = "Tcp"
   port                = 80


### PR DESCRIPTION
This pull request introduces updates to the CI/CD workflow and Terraform configuration. The workflow changes improve branch handling and conditional job execution, while the Terraform changes adjust resource definitions for better alignment with infrastructure needs.

### CI/CD Workflow Updates:
* [`.github/workflows/workflow.yaml`](diffhunk://#diff-fde0e5d64aae13964fdda6d47af304cf1a7015cbc17e440ac4a5e662ee1d875eR7): Added the `develop` branch to the `push` trigger, allowing the workflow to run on both `main` and `develop` branches.
* [`.github/workflows/workflow.yaml`](diffhunk://#diff-fde0e5d64aae13964fdda6d47af304cf1a7015cbc17e440ac4a5e662ee1d875eR33): Added a conditional statement to the `Deploy` job to ensure it only runs when the `main` branch is the active reference.

### Terraform Configuration Adjustment:
* [`terraform/azure/main.tf`](diffhunk://#diff-a72b7b93508224bfaeef0ffa2613d32b06136b4b3c4b8d7f32557def0f2e216eL189): Removed the `resource_group_name` attribute from the `azurerm_lb_probe` resource, likely to simplify or align with other configurations.