### PR TITLE
Atualizar versão do Terraform para 1.11.4 e corrigir descrição do out…

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -7,7 +7,7 @@ on:
     - develop
 
 env:
-  TERRAFORM_VERSION  : 1.11.3
+  TERRAFORM_VERSION  : 1.11.4
   ARM_CLIENT_ID      : ${{ secrets.ARM_CLIENT_ID }}
   ARM_CLIENT_SECRET  : ${{ secrets.ARM_CLIENT_SECRET }}
   ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}

--- a/terraform/azure/output.tf
+++ b/terraform/azure/output.tf
@@ -1,4 +1,19 @@
-output "lb_fqdn" {
+output "lb_url" {
   value       = "http://${azurerm_public_ip.lb.fqdn}"
-  description = "FQDN público do Load Balancer"
+  description = "URL pública do Load Balancer"
+}
+
+output "lb_public_ip" {
+  value       = azurerm_public_ip.lb.ip_address
+  description = "IP público do Load Balancer"
+}
+
+output "vm01_public_ip" {
+  value       = azurerm_public_ip.vm01.ip_address
+  description = "IP público da VM01"
+}
+
+output "vm02_public_ip" {
+  value       = azurerm_public_ip.vm02.ip_address
+  description = "IP público da VM02"
 }


### PR DESCRIPTION
This pull request includes updates to the Terraform configuration and workflow environment to enhance clarity and functionality. The most important changes involve updating the Terraform version in the CI/CD workflow and adding new output variables for better resource visibility.

### Workflow updates:
* Updated the `TERRAFORM_VERSION` in `.github/workflows/workflow.yaml` from `1.11.3` to `1.11.4` to ensure compatibility with the latest Terraform features and fixes.

### Terraform configuration updates:
* Renamed the `lb_fqdn` output to `lb_url` and updated its description for better clarity.
* Added three new output variables in `terraform/azure/output.tf`:
  - [`lb_public_ip`](diffhunk://#diff-5010354209923ed49f259468ac14b811ad044189bf5268caa6179ff03fa37738L1-R18): Outputs the public IP address of the Load Balancer.
  - [`vm01_public_ip`](diffhunk://#diff-5010354209923ed49f259468ac14b811ad044189bf5268caa6179ff03fa37738L1-R18): Outputs the public IP address of VM01.
  - [`vm02_public_ip`](diffhunk://#diff-5010354209923ed49f259468ac14b811ad044189bf5268caa6179ff03fa37738L1-R18): Outputs the public IP address of VM02.